### PR TITLE
Only send alert when feed is enabled in configuration.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -137,7 +137,7 @@ class Parser
          * Empty mail parsing results is useally a problem. So if the resultset is empty we set a single warning
          * to trigger an alert if the warning is set to error in the config.
          */
-        if (empty($this->incidents)) {
+        if (empty($this->incidents) && $this->isEnabledFeed()) {
             $this->warningCount++;
             Log::warning(
                 get_class($this) . ': ' .


### PR DESCRIPTION
Currently, AbuseIO sends alerts out when a disabled feed did not return any incidents, which is "expected", since it is disabled in the configuration. This commit changes the logic in that, so AbuseIO does not send out any alerts when a feed is _not_ enabled.

Now, I dont know whether this is the perfect "solution" for this, but it worked quite well in my configuration. So might aswell give this PR a shot :)

Let me know if I need to make some changes (or do 'em yourself, also possible :>)